### PR TITLE
Fix for image resizing using a layer, and fix for non-us-east-1 buckets

### DIFF
--- a/resources.js
+++ b/resources.js
@@ -71,8 +71,11 @@ module.exports = function upload (arc, cfn) {
     Properties: {
       Handler: 'index.handler',
       CodeUri: './src/upload',
-      Runtime: 'nodejs12.x',
+      Runtime: 'nodejs10.x',
       MemorySize: 3008,
+      Layers: [
+        {'Fn::GetAtt': ['ImageMagick', 'Outputs.LayerVersion']}
+      ],
       Timeout: 60,
       Environment: {
         Variables: {}
@@ -82,6 +85,16 @@ module.exports = function upload (arc, cfn) {
           'arn:aws:iam::${AWS::AccountId}:role/${role}',
           { role: { Ref: 'UploadRole' } }
         ]
+      }
+    }
+  }
+
+  cfn.Resources.ImageMagick = {
+    Type: 'AWS::Serverless::Application',
+    Properties: {
+      Location: {
+        ApplicationId: 'arn:aws:serverlessrepo:us-east-1:145266761615:applications/image-magick-lambda-layer',
+        SemanticVersion: '1.0.0'
       }
     }
   }

--- a/resources.js
+++ b/resources.js
@@ -74,6 +74,8 @@ module.exports = function upload (arc, cfn) {
       Runtime: 'nodejs10.x',
       MemorySize: 3008,
       Layers: [
+        // We get the below layer, which contains Image Magick binaries, from
+        // the serverless 'application' we incorporate at the end of this file
         {'Fn::GetAtt': ['ImageMagick', 'Outputs.LayerVersion']}
       ],
       Timeout: 60,
@@ -89,6 +91,9 @@ module.exports = function upload (arc, cfn) {
     }
   }
 
+  // Create a nested stack of this 'application' so we can reference the image
+  // magick bits its provides as a layer
+  // App: https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:145266761615:applications~image-magick-lambda-layer
   cfn.Resources.ImageMagick = {
     Type: 'AWS::Serverless::Application',
     Properties: {

--- a/s3.js
+++ b/s3.js
@@ -8,7 +8,7 @@ var crypto = require('crypto')
 // * secretKey
 module.exports = function s3Credentials (config, params) {
   return {
-    endpoint: 'https://' + config.bucket + '.s3.amazonaws.com',
+    endpoint: 'https://' + config.bucket + '.' + config.region + '.s3.amazonaws.com',
     params: s3Params(config, params)
   }
 }


### PR DESCRIPTION
Two fixes here:

- the URL the form generates for POSTing to the bucket should include the region, in case the bucket is not located in us-east-1
- added a "serverless app" to the CFN resources list which includes a lambda layer that has the image magick goodies

The good:
- don't have to build your own layer, is publicly available

The bad:
- the image manipulation function requires node v10

The ugly:
- the 'serverless app' resource ends up building a nested stack that becomes part of your app; all of that just for one stinking layer

Applying these changes and then using it with https://github.com/architect-examples/arc-example-macro-upload works great for me!